### PR TITLE
Option to enable SDL2

### DIFF
--- a/App/index.htm
+++ b/App/index.htm
@@ -361,6 +361,11 @@
 				
 				</div>
 
+                <!-- SDL2 option -->
+                <br>
+                <input type="checkbox" id="CHECKBOX_optionsEnableSDL2" oninput="APP.gameList.saveGameSettings(!0);APP.design.update();APP.gameList.checkSdl2();">
+                <label class="LABEL_checkbox" id="LABEL_FPPS4_OPTIONS_ENABLE_SDL2" onclick="APP.gameList.toggleSdl2();APP.gameList.checkSdl2();"> Enable SDL2</label>
+
 				<!-- Launcher Options -->
 				<div class="DIV_launcherOptions">
 					<div class="DIV_launcherOptionsTitle" id="LABEL_FPPS4_OPTIONS_LAUNCHER_OPTIONS">

--- a/App/js/emumanager.js
+++ b/App/js/emumanager.js
@@ -55,6 +55,10 @@ temp_EMUMANAGER = {
 				}
 			});
 
+				if (document.getElementById('CHECKBOX_optionsEnableSDL2').checked === !0){
+					emuArgs.push('-pad "sdl2"');
+				}
+
 			// Add fullscreen flag if it's enabled
 			if (APP.settings.data.enableEmuFullscreen === !0){
 				emuArgs.push('-w');

--- a/App/js/gamelist.js
+++ b/App/js/gamelist.js
@@ -127,6 +127,42 @@ temp_GAMELIST = {
 
 	},
 
+    // Check for SDL2.dll in emu folder
+    checkSdl2: function() {
+        // check if the checkbox is checked (so people can disable it normally)
+        if (document.getElementById("CHECKBOX_optionsEnableSDL2").checked) {
+
+            // Get path for sdl2.dll
+            const sdl2Path = APP.tools.fixPath(nw.__dirname) + "/Emu/SDL2.dll";
+
+            // Check if sdl2.dll exists and give an alert when its not found
+            if (!APP.fs.existsSync(sdl2Path)) {
+                window.alert("SDL2.dll is not found in the Emu folder, please install it to use SDL2.");
+            }
+        }
+    },
+
+    // Toggle enable / disable SDL2
+	toggleSdl2: function(){
+
+		// Get current game id
+		const cGame = this.selectedGame,
+			listTop = document.getElementById('DIV_LIST_INTERNAL').scrollTop;
+
+		// Update GUI
+		APP.tools.processCheckbox('CHECKBOX_optionsEnableSDL2');
+		this.saveGameSettings(!0);
+		APP.design.update();
+		this.load();
+
+		// Select current game
+		APP.design.selectGame(cGame);
+
+		// Update scroll
+		document.getElementById('DIV_LIST_INTERNAL').scrollTop = listTop;
+
+	},
+
 	// Load game patch
 	loadGamePatch: function(){
 

--- a/App/js/gamelist.js
+++ b/App/js/gamelist.js
@@ -137,7 +137,7 @@ temp_GAMELIST = {
 
             // Check if sdl2.dll exists and give an alert when its not found
             if (!APP.fs.existsSync(sdl2Path)) {
-                window.alert("SDL2.dll is not found in the Emu folder, please install it to use SDL2.");
+                window.alert(APP.lang.getVariable("Sdl2NotFound"));
             }
         }
     },

--- a/App/js/language.js
+++ b/App/js/language.js
@@ -110,7 +110,8 @@ temp_LANGUAGE = {
 			"dumpStatus_WARN": "Missing files",
 			"dumpStatus_HB": "Homebrew",
 			"updateEmuWorkflow404": "ERROR - (Updater) Unable to locate selected CI workflow from fpPS4 GitHub!",
-			"updater_noWorkflowListAvailable": "No workflow list available"
+			"updater_noWorkflowListAvailable": "No workflow list available",
+            "Sdl2NotFound": "SDL2.dll is not found in the Emu folder, please install it to use SDL2."
 
 		},
 

--- a/Lang/nl-nl.json
+++ b/Lang/nl-nl.json
@@ -61,8 +61,9 @@
 		"dumpStatus_OK": "Prima",
 		"dumpStatus_WARN": "Missende bestanden",
 		"dumpStatus_HB": "Homebrew",
-		"updateEmuWorkflow404": "",
-		"updater_noWorkflowListAvailable": ""
+		"updateEmuWorkflow404": "ERROR - (Updater) De geselecteerde CI workflow kon niet gevonden worden in de fpPS4 GitHub!",
+		"updater_noWorkflowListAvailable": "geen workflow lijst beschikbaar",
+        "Sdl2NotFound": "SDL2.dll is niet gevonden in de Emu map, installeer het om SDL2 te gebruiken."
 	},
 
 	"input_text": {
@@ -102,6 +103,7 @@
 		"LABEL_FPPS4_OPTIONS": "<label class=\"LABEL_emuColor\">fp</label>PS4 Opties",
 		"LABEL_FPPS4_OPTIONS_DUMP_STATUS": "Dump Status",
 		"LABEL_FPPS4_OPTIONS_ENABLE_PATCHES": "Patches Activeren",
+        "LABEL_FPPS4_OPTIONS_ENABLE_SDL2": "SDL2 Activeren",
 		"LABEL_FPPS4_OPTIONS_PATCH_VERSION": "Versie",
 		"LABEL_FPPS4_OPTIONS_PATCH_TYPE": "Type",
 		"LABEL_EMU_RUNNING_STATUS": "Status",


### PR DESCRIPTION
I added an option to enable SDL2, when you click on the checkbox it will do a check to see if the SDL2.dll is in the emu folder and if it's not it will give an window.alert with the following message: `SDL2.dll is not found in the Emu folder, please install it to use SDL2.`.

People can choose to ignore the message, however if you don't want that you can just set the checkbox to unchecked after the window alert.

When the game gets launched it checks if the checkbox is enabled and adds the following arguments `-pad "sdl2"` to enable sdl2.
